### PR TITLE
give more informative error messages if sudo was not found

### DIFF
--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -217,7 +217,7 @@ cd "$ORIG_PWD"
     test "$bash_symbol" = "$" || echo '`get_prompt_symbol` !== "$" for a normal user' 1>&2
 
   # with root
-  if which sudo &> /dev/null && sudo -n true; then
+  if which sudo &> /dev/null; then
     bash_symbol="$(sudo bash --norc --noprofile -i -c '. .bash_prompt; echo $(get_prompt_symbol)')";
 
     # is #


### PR DESCRIPTION
Doing some testing for the latency issues we've been discussing on my cygwin system. In cygwin there is no sudo, so this test would fail with an inappropriate error message. I added a dependency check before running the test so that if sudo isn't installed, or we don't have privileges to run it, there's a clear error message. 
