### PR TITLE
Moved to `$HOME` to support Windows install. Fixes #45

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GIT_DIRS := $(wildcard test/test-files/*/.git)
 
 install:
 	@echo "# Copying .bash_prompt to ~/.bash_prompt"
-	cp -f .bash_prompt ~/.bash_prompt
+	cp -f ".bash_prompt" "$(HOME)/.bash_prompt"
 
 	@# Run install script
 	./install.bash
@@ -14,7 +14,7 @@ install:
 
 install-link:
 	@echo "# Linking .bash_prompt to ~/.bash_prompt"
-	ln -f -s $(PWD)/.bash_prompt $(HOME)/.bash_prompt
+	ln -f -s "$(PWD)/.bash_prompt" "$(HOME)/.bash_prompt"
 
 	@# Run install script
 	./install.bash

--- a/README.md
+++ b/README.md
@@ -49,24 +49,25 @@ rm /tmp/.bash_prompt_term
 
 ### Manual install
 ```bash
-$ # Clone the repository
-$ git clone --depth 1 https://github.com/twolfson/sexy-bash-prompt
-Cloning into 'sexy-bash-prompt'...
-...
-Resolving deltas: 100% (13/13), done.
-$ # Go into the directory
-$ cd sexy-bash-prompt
-$ # Install the script
-$ make install
-# Copying .bash_prompt to ~/.bash_prompt
-cp --force .bash_prompt ~/.bash_prompt
-# Adding ~/.bash_prompt to ~/.bashrc
-echo ". ~/.bash_prompt" >> ~/.bashrc
-# twolfson/sexy-bash-prompt installation complete!
-$ # Rerun your ~/.bashrc
-$ source ~/.bashrc
-todd at Euclid in ~/github/sexy-bash-prompt on master
-$ # Your PS1 should now look like this!
+# Clone the repository
+git clone --depth 1 https://github.com/twolfson/sexy-bash-prompt
+# Cloning into 'sexy-bash-prompt'...
+# ...
+# Resolving deltas: 100% (13/13), done.
+
+# Go into the directory
+cd sexy-bash-prompt
+# Install the script
+make install
+# # Copying .bash_prompt to ~/.bash_prompt
+# cp -f ".bash_prompt" "/home/todd/.bash_prompt"
+# ./install.bash
+# # twolfson/sexy-bash-prompt installation complete!
+
+# Rerun your ~/.bashrc
+source ~/.bashrc
+# todd at Euclid in ~/github/sexy-bash-prompt on master
+# Your PS1 should now look like this!
 ```
 
 ## Configuration


### PR DESCRIPTION
As reported in #45, `make install` was not working inside of `git bash`. It was being caused by using `~` instead of `$HOME` as part of the target destination. This PR fixes that. In this PR:

- Moved from `~` to `$HOME` to fix issue
- Added missing quotes to `install` and `install-link` tasks
- Updated documentation

/cc @rpdelaney 