### PR TITLE
Prompt symbol parsimony

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -57,6 +57,13 @@ else
   sexy_bash_prompt_symbol_color="" # NORMAL
 fi
 
+# Define the default prompt terminator character '$'
+if [[ "$UID" == 0 ]]; then
+  sexy_bash_prompt_symbol="#"
+else
+  sexy_bash_prompt_symbol="\$"
+fi
+
 # Apply any color overrides that have been set in the environment
 if [[ -n "$PROMPT_USER_COLOR" ]]; then sexy_bash_prompt_user_color="$PROMPT_USER_COLOR"; fi
 if [[ -n "$PROMPT_PREPOSITION_COLOR" ]]; then sexy_bash_prompt_preposition_color="$PROMPT_PREPOSITION_COLOR"; fi
@@ -64,6 +71,7 @@ if [[ -n "$PROMPT_DEVICE_COLOR" ]]; then sexy_bash_prompt_device_color="$PROMPT_
 if [[ -n "$PROMPT_DIR_COLOR" ]]; then sexy_bash_prompt_dir_color="$PROMPT_DIR_COLOR"; fi
 if [[ -n "$PROMPT_GIT_STATUS_COLOR" ]]; then sexy_bash_prompt_git_status_color="$PROMPT_GIT_STATUS_COLOR"; fi
 if [[ -n "$PROMPT_GIT_PROGRESS_COLOR" ]]; then sexy_bash_prompt_git_progress_color="$PROMPT_GIT_PROGRESS_COLOR"; fi
+if [[ -n "$PROMPT_SYMBOL" ]]; then sexy_bash_prompt_symbol="$PROMPT_SYMBOL"; fi
 if [[ -n "$PROMPT_SYMBOL_COLOR" ]]; then sexy_bash_prompt_symbol_color="$PROMPT_SYMBOL_COLOR"; fi
 
 # Set up symbols
@@ -247,16 +255,6 @@ sexy_bash_prompt_get_git_info () {
   fi
 }
 
-# Symbol displayed at the line of every prompt
-function sexy_bash_prompt_get_prompt_symbol() {
-  # If we are root, display `#`. Otherwise, `$`
-  if [[ "$UID" == 0 ]]; then
-    echo "#"
-  else
-    echo "\$"
-  fi
-}
-
 # Define the sexy-bash-prompt
 PS1="\[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] \
 \[$sexy_bash_prompt_preposition_color\]at\[$sexy_bash_prompt_reset\] \
@@ -268,4 +266,4 @@ PS1="\[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] \
   echo -n \"\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)\" && \
   echo -n \"\[$sexy_bash_prompt_git_progress_color\]\$(sexy_bash_prompt_get_git_progress)\" && \
   echo -n \"\[$sexy_bash_prompt_preposition_color\]\")\n\[$sexy_bash_prompt_reset\]\
-\[$sexy_bash_prompt_symbol_color\]$(sexy_bash_prompt_get_prompt_symbol) \[$sexy_bash_prompt_reset\]"
+\[$sexy_bash_prompt_symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -278,7 +278,11 @@ esc=$'\033'
     PROMPT_UNPUSHED_SYMBOL='#unpushed' PROMPT_DIRTY_UNPUSHED_SYMBOL='#dirty-unpushed' \
     PROMPT_UNPULLED_SYMBOL='#unpulled' PROMPT_DIRTY_UNPULLED_SYMBOL='#dirty-unpulled' \
     PROMPT_UNPUSHED_UNPULLED_SYMBOL='#unpushed-unpulled' PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL='#dirty-unpushed-unpulled' \
+    PROMPT_SYMBOL='#prompt-symbol' \
     . .bash_prompt
+
+    # the prompt always uses the PROMPT_SYMBOL
+    test "$sexy_bash_prompt_symbol" = "#prompt-symbol" || echo 'sexy_bash_prompt_symbol was not overridden by PROMPT_SYMBOL as expected' 1>&2
 
     # a synced prompt uses the new symbol
     fixture_dir 'synced'

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -207,21 +207,21 @@ cd "$ORIG_PWD"
     # does not have any output
     test ${#prompt_output} -eq 0 || echo '`prompt_output` did not have length 0' 1>&2
 
-# sexy_bash_prompt_get_prompt_symbol
+# sexy_bash_prompt_symbol
 cd "$ORIG_PWD"
 
   # with a normal user
-  bash_symbol="$(bash --norc --noprofile -i -c '. .bash_prompt; echo $(sexy_bash_prompt_get_prompt_symbol)')"
+  bash_symbol="$(bash --norc --noprofile -i -c '. .bash_prompt; echo "$sexy_bash_prompt_symbol"')"
 
     # is $
-    test "$bash_symbol" = "$" || echo '`sexy_bash_prompt_get_prompt_symbol` !== "$" for a normal user' 1>&2
+    test "$bash_symbol" = "$" || echo '`sexy_bash_prompt_symbol` !== "$" for a normal user' 1>&2
 
   # with root
   if which sudo &> /dev/null; then
-    bash_symbol="$(sudo bash --norc --noprofile -i -c '. .bash_prompt; echo $(sexy_bash_prompt_get_prompt_symbol)')";
+    bash_symbol="$(sudo bash --norc --noprofile -i -c '. .bash_prompt; echo "$sexy_bash_prompt_symbol"')";
 
     # is #
-    test "$bash_symbol" = "#" || echo '`sexy_bash_prompt_get_prompt_symbol` !== "#" for root' 1>&2
+    test "$bash_symbol" = "#" || echo '`sexy_bash_prompt_symbol` !== "#" for root' 1>&2
   else
     echo "WARNING: sudo not found or insufficient privileges. Test skipped." 1>&2
   fi


### PR DESCRIPTION
Because we define the prompt symbol as '$' or '#' according to the value of `$UID`, it is unnecessary to re-calculate it after every command. Instsead, a substitution is direct and effective.

Further, a substitution supports a `PROMPT_SYMBOL` environment variable for more customizations to the symbol.

Since there is no hard-coded behavior specific to the root account, the dependency on running 'sudo' inside a unit test is dropped.