### PR TITLE
Updated donations link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Forked from [a gist by gf3][sexy-bash-orig].
 [sexy-bash-orig]: https://gist.github.com/gf3/306785/a35d28b6bdd0f7c54318cce510738438f04dabaa
 
 ### Do you like `sexy-bash-prompt`?
-[Support us via gratipay][gratipay] or [spread word on Twitter][twitter]
+[Support us via donations][donations] or [spread word on Twitter][twitter]
 
-[gratipay]: https://gratipay.com/sexybashprompt/
+[donations]: http://bit.ly/support-sexy-bash-prompt
 [twitter]: https://twitter.com/intent/tweet?text=Bash%20prompt%20with%20colors%2C%20git%20statuses%2C%20and%20git%20branches&url=https%3A%2F%2Fgithub.com%2Ftwolfson%2Fsexy-bash-prompt&via=sexybashprompt
 
 ## Installation


### PR DESCRIPTION
Our application to the Gratipay was rejected for now. Unfortunately, I don't currently have the time to perform a rename of all our assets (e.g. repo, screenshots, Twitter account).

As a temporary stop-gap (and to start seeing how many people are interested in donating), we are adding in a bit.ly link to a Flattr page for now.

In this PR:

- Updated donation link to use bit.ly pointing to Flattr

/cc @rpdelaney 