### PR TITLE
Added foundry for release

### DIFF
--- a/.foundryrc
+++ b/.foundryrc
@@ -1,0 +1,5 @@
+{
+  "releaseCommands": [
+    "foundry-release-git"
+  ]
+}

--- a/release.bash
+++ b/release.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Exit on first error
+set -e
+
+# Install our dependencies
+npm install foundry@~4.3.2 foundry-release-git@~2.0.2
+
+# Run foundry release with an adjusted PATH
+PATH="$PATH:$PWD/node_modules/.bin/"
+foundry release $*


### PR DESCRIPTION
In the past, I have performed releases via `foundry` with a global CLI tool. In its v4 iteration, it moved to be exclusively a local per-project setup.

http://twolfson.com/2015-10-17-release-foundry-v4

This PR adds the necessary files to make releases reproducable across collaborators. In this PR:

- Added `release.sh` (used via `./release.sh <semver>`)
- Added `.foundryrc`

/cc @rpdelaney 