### PR TITLE
Added node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test.stderr
+node_modules/


### PR DESCRIPTION
We forgot to add `node_modules` to the `.gitignore` as part of the `foundry` PR. This accounts for ignoring that folder =/