### PR TITLE
Compute remote and tracking branch names

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -164,7 +164,15 @@ sexy_bash_prompt_branch_exists () {
 sexy_bash_prompt_parse_git_ahead () {
   # Grab the local and remote branch
   branch="$(sexy_bash_prompt_get_git_branch)"
-  remote_branch="origin/$branch"
+  
+  #remote_branch="origin/$branch"
+  #Compute the remote tracking branch, if no remote branch then echo 0
+  branchnamefull=$(git symbolic-ref -q HEAD);
+  remote_branch=$(git for-each-ref --format='%(upstream:short)' $branchnamefull)
+  if [ "$remote_branch" = "" ]
+    then
+      echo 0; return;
+  fi
 
   # $ git log origin/master..master
   # commit 4a633f715caf26f6e9495198f89bba20f3402a32
@@ -185,7 +193,15 @@ sexy_bash_prompt_parse_git_ahead () {
 sexy_bash_prompt_parse_git_behind () {
   # Grab the branch
   branch="$(sexy_bash_prompt_get_git_branch)"
-  remote_branch="origin/$branch"
+
+  #remote_branch="origin/$branch"
+  #Compute the remote tracking branch, if no remote branch then echo 0
+  branchnamefull=$(git symbolic-ref -q HEAD);
+  remote_branch=$(git for-each-ref --format='%(upstream:short)' $branchnamefull)
+  if [ "$remote_branch" = "" ]
+    then
+      echo 0; return;
+  fi
 
   # $ git log master..origin/master
   # commit 4a633f715caf26f6e9495198f89bba20f3402a32

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -167,7 +167,7 @@ sexy_bash_prompt_parse_git_ahead () {
   
   # remote_branch="origin/$branch"
   # Compute the remote tracking branch, if no remote branch then echo 0
-  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" 2>/dev/null )"
+  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" 2>/dev/null || echo -n "origin/$branch")"
   if [[  "$remote_branch" == "" ]]
     then
       echo 0; return;
@@ -195,7 +195,7 @@ sexy_bash_prompt_parse_git_behind () {
 
   # remote_branch="origin/$branch"
   # Compute the remote tracking branch, if no remote branch then echo 0
-  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" 2>/dev/null )"
+  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" 2>/dev/null || echo -n "origin/$branch")"
   if [[ "$remote_branch" == "" ]]
     then
       echo 0; return;

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -169,7 +169,7 @@ sexy_bash_prompt_parse_git_ahead () {
   #Compute the remote tracking branch, if no remote branch then echo 0
   branchnamefull=$(git symbolic-ref -q HEAD);
   remote_branch=$(git for-each-ref --format='%(upstream:short)' $branchnamefull)
-  if [ "$remote_branch" = "" ]
+  if [[  "$remote_branch" == "" ]]
     then
       echo 0; return;
   fi
@@ -198,7 +198,7 @@ sexy_bash_prompt_parse_git_behind () {
   #Compute the remote tracking branch, if no remote branch then echo 0
   branchnamefull=$(git symbolic-ref -q HEAD);
   remote_branch=$(git for-each-ref --format='%(upstream:short)' $branchnamefull)
-  if [ "$remote_branch" = "" ]
+  if [[ "$remote_branch" == "" ]]
     then
       echo 0; return;
   fi

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -165,10 +165,9 @@ sexy_bash_prompt_parse_git_ahead () {
   # Grab the local and remote branch
   branch="$(sexy_bash_prompt_get_git_branch)"
   
-  #remote_branch="origin/$branch"
-  #Compute the remote tracking branch, if no remote branch then echo 0
-  branchnamefull=$(git symbolic-ref -q HEAD);
-  remote_branch=$(git for-each-ref --format='%(upstream:short)' $branchnamefull)
+  # remote_branch="origin/$branch"
+  # Compute the remote tracking branch, if no remote branch then echo 0
+  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}")"  
   if [[  "$remote_branch" == "" ]]
     then
       echo 0; return;
@@ -194,10 +193,9 @@ sexy_bash_prompt_parse_git_behind () {
   # Grab the branch
   branch="$(sexy_bash_prompt_get_git_branch)"
 
-  #remote_branch="origin/$branch"
-  #Compute the remote tracking branch, if no remote branch then echo 0
-  branchnamefull=$(git symbolic-ref -q HEAD);
-  remote_branch=$(git for-each-ref --format='%(upstream:short)' $branchnamefull)
+  # remote_branch="origin/$branch"
+  # Compute the remote tracking branch, if no remote branch then echo 0
+  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}")"  
   if [[ "$remote_branch" == "" ]]
     then
       echo 0; return;

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -167,7 +167,7 @@ sexy_bash_prompt_parse_git_ahead () {
   
   # remote_branch="origin/$branch"
   # Compute the remote tracking branch, if no remote branch then echo 0
-  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}")"  
+  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" 2>/dev/null )"
   if [[  "$remote_branch" == "" ]]
     then
       echo 0; return;
@@ -195,7 +195,7 @@ sexy_bash_prompt_parse_git_behind () {
 
   # remote_branch="origin/$branch"
   # Compute the remote tracking branch, if no remote branch then echo 0
-  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}")"  
+  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" 2>/dev/null )"
   if [[ "$remote_branch" == "" ]]
     then
       echo 0; return;


### PR DESCRIPTION
Do not assume remote to be called "origin" but use the git for-each-ref
command to get the explicit remote ref name for the current working branch.