### PR TITLE
Added tests for upstream tracking branches

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -164,7 +164,7 @@ sexy_bash_prompt_branch_exists () {
 sexy_bash_prompt_parse_git_ahead () {
   # Grab the local and remote branch
   branch="$(sexy_bash_prompt_get_git_branch)"
-  remote_branch="origin/$branch"
+  remote_branch="$(echo -n "origin/$branch")"
 
   # $ git log origin/master..master
   # commit 4a633f715caf26f6e9495198f89bba20f3402a32
@@ -185,7 +185,7 @@ sexy_bash_prompt_parse_git_ahead () {
 sexy_bash_prompt_parse_git_behind () {
   # Grab the branch
   branch="$(sexy_bash_prompt_get_git_branch)"
-  remote_branch="origin/$branch"
+  remote_branch="$(echo -n "origin/$branch")"
 
   # $ git log master..origin/master
   # commit 4a633f715caf26f6e9495198f89bba20f3402a32

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -164,7 +164,8 @@ sexy_bash_prompt_branch_exists () {
 sexy_bash_prompt_parse_git_ahead () {
   # Grab the local and remote branch
   branch="$(sexy_bash_prompt_get_git_branch)"
-  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" || echo -n "origin/$branch")"
+  remote="$(git config --get "branch.${branch}.remote" || echo -n "origin")"
+  remote_branch="$remote/$branch"
 
   # $ git log origin/master..master
   # commit 4a633f715caf26f6e9495198f89bba20f3402a32
@@ -185,7 +186,8 @@ sexy_bash_prompt_parse_git_ahead () {
 sexy_bash_prompt_parse_git_behind () {
   # Grab the branch
   branch="$(sexy_bash_prompt_get_git_branch)"
-  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" || echo -n "origin/$branch")"
+  remote="$(git config --get "branch.${branch}.remote" || echo -n "origin")"
+  remote_branch="$remote/$branch"
 
   # $ git log master..origin/master
   # commit 4a633f715caf26f6e9495198f89bba20f3402a32

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -164,7 +164,7 @@ sexy_bash_prompt_branch_exists () {
 sexy_bash_prompt_parse_git_ahead () {
   # Grab the local and remote branch
   branch="$(sexy_bash_prompt_get_git_branch)"
-  remote_branch="$(echo -n "origin/$branch")"
+  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" || echo -n "origin/$branch")"
 
   # $ git log origin/master..master
   # commit 4a633f715caf26f6e9495198f89bba20f3402a32
@@ -185,7 +185,7 @@ sexy_bash_prompt_parse_git_ahead () {
 sexy_bash_prompt_parse_git_behind () {
   # Grab the branch
   branch="$(sexy_bash_prompt_get_git_branch)"
-  remote_branch="$(echo -n "origin/$branch")"
+  remote_branch="$(git rev-parse --symbolic-full-name "@{upstream}" || echo -n "origin/$branch")"
 
   # $ git log master..origin/master
   # commit 4a633f715caf26f6e9495198f89bba20f3402a32

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -137,8 +137,12 @@ fixture_git_init() {
     test "$(sexy_bash_prompt_get_git_status)" = "⬡" || echo '`sexy_bash_prompt_get_git_status` !== "⬡" on an unpushed and unpulled branch with a tracked non-origin remote' 1>&2
 
   # on an unpushed and unpulled branch with an untracked origin remote
+  # DEV: Due to git@1.7, we need to use `config --unset` instead of `git branch --unset-upstream`
+  # DEV: On git@1.7 `git rev-parse --symbolic-full-name "@{upstream}"` returns `@{upstream}` instead of erroring out
   fixture_dir 'unpushed-unpulled'
-  git branch --unset-upstream
+  git config --unset branch.master.remote
+  git config --unset branch.master.merge
+  test "$(git rev-parse --symbolic-full-name "@{upstream}" 2> /dev/null | grep --invert-match "@{upstream}")" = "" || echo 'Expected untracked unpushed-unpulled to have no tracked origin but it did not' 1>&2
 
     # is an empty hexagon
     test "$(sexy_bash_prompt_get_git_status)" = "⬡" || echo '`sexy_bash_prompt_get_git_status` !== "⬡" on an unpushed and unpulled branch with an untracked origin remote' 1>&2

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -122,6 +122,34 @@ fixture_git_init() {
     # is an filled hexagon
     test "$(sexy_bash_prompt_get_git_status)" = "⬢" || echo '`sexy_bash_prompt_get_git_status` !== "⬢" on a dirty, unpushed, and unpulled branch' 1>&2
 
+  # on an unpushed and unpulled branch with a tracked origin remote
+  fixture_dir 'unpushed-unpulled'
+  test "$(git rev-parse --symbolic-full-name "@{upstream}")" != "" || echo 'Expected unpushed-unpulled to have tracked origin but it did not' 1>&2
+
+    # is an empty hexagon
+    test "$(sexy_bash_prompt_get_git_status)" = "⬡" || echo '`sexy_bash_prompt_get_git_status` !== "⬡" on an unpushed and unpulled branch with a tracked origin remote' 1>&2
+
+  # on an unpushed and unpulled branch with a tracked non-origin remote
+  fixture_dir 'unpushed-unpulled'
+  git remote rename origin non-origin
+
+    # is an empty hexagon
+    test "$(sexy_bash_prompt_get_git_status)" = "⬡" || echo '`sexy_bash_prompt_get_git_status` !== "⬡" on an unpushed and unpulled branch with a tracked non-origin remote' 1>&2
+
+  # on an unpushed and unpulled branch with an untracked origin remote
+  fixture_dir 'unpushed-unpulled'
+  git branch --unset-upstream
+
+    # is an empty hexagon
+    test "$(sexy_bash_prompt_get_git_status)" = "⬡" || echo '`sexy_bash_prompt_get_git_status` !== "⬡" on an unpushed and unpulled branch with an untracked origin remote' 1>&2
+
+  # on an unpushed branch with no remote
+  fixture_dir 'unpushed'
+  git remote rm origin
+
+    # is an empty up triangle
+    test "$(sexy_bash_prompt_get_git_status)" = "△" || echo '`sexy_bash_prompt_get_git_status` !== "△" on an unpushed branch with no remote' 1>&2
+
 # git_progress
 
   # on a clean branch


### PR DESCRIPTION
This is a supplemental PR to #69 which adds in tests. When #69 is landed, this will be squashed/landed on top of it so everyone gets their appropriate attribution. In this PR:

- Original patches for #69 
- Added tests to verify all cases of branches

/cc @rpdelaney 