### PR TITLE
Show what branch we cherry-pick'd from

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -129,7 +129,7 @@ function sexy_bash_prompt_get_git_progress() {
     echo " [rebase]"
   elif [[ -f "$git_dir/CHERRY_PICK_HEAD" ]]; then
     # git cherry-pick
-    echo " [cherry-pick]"
+    echo " [cherry-pick from $(git branch -vv | grep '\*' | awk '{print $7}')]"
   fi
   if [[ -f "$git_dir/BISECT_LOG" ]]; then
     # git bisect

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -129,7 +129,7 @@ function sexy_bash_prompt_get_git_progress() {
     echo " [rebase]"
   elif [[ -f "$git_dir/CHERRY_PICK_HEAD" ]]; then
     # git cherry-pick
-    echo " [cherry-pick from $(git branch -vv | grep '\*' | awk '{print $7}')]"
+    echo " [cherry-pick from $(git branch -vv | grep '^\*' | awk '{print $7}')]"
   fi
   if [[ -f "$git_dir/BISECT_LOG" ]]; then
     # git bisect


### PR DESCRIPTION
This produces a prompt as follows. This helps me in my day to day workflow to know what I cherry-pick'd from.

```
[phil@myserver ~/work/somerepository] on master△ [cherry-pick from SOME_BRANCH_NAME]
```