### PR TITLE
Fix #51: Create ~/.bash_profile when no profile found

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -30,8 +30,9 @@ elif [[ -f ~/.profile ]]; then
   profile_script_short="~/.profile"
   profile_script_full=~/.profile
 else
-  echo "FATAL: Profile script not found." 1>&2
-  exit 1
+  touch ~/.bash_profile
+  profile_script_short="~/.bash_profile"
+  profile_script_full=~/.bash_profile
 fi
 
 # If the current script does not have notes about .bashrc


### PR DESCRIPTION
Often people run this script on a brand new computer as part of the setup process and its common for profile to not exist (see #51 and #62)