### PR TITLE
Added instructions to handle prompt not found

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -30,7 +30,7 @@ elif [[ -f ~/.profile ]]; then
   profile_script_short="~/.profile"
   profile_script_full=~/.profile
 else
-  echo "FATAL: Profile script not found." 1>&2
+  echo "FATAL: Profile script not found. Please create one via \`touch ~/.bash_profile\` or a similar file (e.g. \`~/.bash_login\`, \`~/.profile\`)" 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
As discussed in #78, we'd like to add instructions to users so they can decide what to do when no prompt is found. In this PR:

- Added instructions to handle when prompt isn't found
- Fixes #84 