### PR TITLE
Moved to PROMPT_COMMAND

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -270,7 +270,7 @@ sexy_bash_prompt_command () {
   PS1="$PS1\[$sexy_bash_prompt_device_color\]\h\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_preposition_color\]in\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_dir_color\]\w\[$sexy_bash_prompt_reset\]"
-  if [[ sexy_bash_prompt_is_on_git ]]; then
+  if sexy_bash_prompt_is_on_git; then
     PS1="$PS1 \[$sexy_bash_prompt_preposition_color\]on\[$sexy_bash_prompt_reset\] "
     PS1="$PS1\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)"
     PS1="$PS1\[$sexy_bash_prompt_git_progress_color\]\$(sexy_bash_prompt_get_git_progress)"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -258,18 +258,26 @@ sexy_bash_prompt_get_git_info () {
 }
 
 sexy_bash_prompt_command () {
-  PS1="$?\[$sexy_bash_prompt_reset\]\
-  \[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] \
-  \[$sexy_bash_prompt_preposition_color\]at\[$sexy_bash_prompt_reset\] \
-  \[$sexy_bash_prompt_device_color\]\h\[$sexy_bash_prompt_reset\] \
-  \[$sexy_bash_prompt_preposition_color\]in\[$sexy_bash_prompt_reset\] \
-  \[$sexy_bash_prompt_dir_color\]\w\[$sexy_bash_prompt_reset\]\
-  \$( sexy_bash_prompt_is_on_git && \
-    echo -n \" \[$sexy_bash_prompt_preposition_color\]on\[$sexy_bash_prompt_reset\] \" && \
-    echo -n \"\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)\" && \
-    echo -n \"\[$sexy_bash_prompt_git_progress_color\]\$(sexy_bash_prompt_get_git_progress)\" && \
-    echo -n \"\[$sexy_bash_prompt_reset\]\")\n\
-  \[$sexy_bash_prompt_symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
+  # Pull down exit code before anything else (otherwise unsets it)
+  # https://stackoverflow.com/a/16715681
+  # https://gist.github.com/weibeld/f3b6e6187029924a9b3d
+  exit_code="$?"
+
+  # Reset our PS1 prompt and start building it up
+  PS1="\[$sexy_bash_prompt_reset\]"
+  PS1="$PS1\[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] "
+  PS1="$PS1\[$sexy_bash_prompt_preposition_color\]at\[$sexy_bash_prompt_reset\] "
+  PS1="$PS1\[$sexy_bash_prompt_device_color\]\h\[$sexy_bash_prompt_reset\] "
+  PS1="$PS1\[$sexy_bash_prompt_preposition_color\]in\[$sexy_bash_prompt_reset\] "
+  PS1="$PS1\[$sexy_bash_prompt_dir_color\]\w\[$sexy_bash_prompt_reset\]"
+  if [[ sexy_bash_prompt_is_on_git ]]; then
+    PS1="$PS1 \[$sexy_bash_prompt_preposition_color\]on\[$sexy_bash_prompt_reset\] "
+    PS1="$PS1\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)"
+    PS1="$PS1\[$sexy_bash_prompt_git_progress_color\]\$(sexy_bash_prompt_get_git_progress)"
+    PS1="$PS1\[$sexy_bash_prompt_reset\]"
+  fi
+  PS1="$PS1\n"
+  PS1="$PS1\[$sexy_bash_prompt_symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
 }
 
 # Define the sexy-bash-prompt

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -263,13 +263,17 @@ sexy_bash_prompt_command () {
   # https://gist.github.com/weibeld/f3b6e6187029924a9b3d
   exit_code="$?"
 
-  # Reset our PS1 prompt and start building it up
+  # Reset our PS1 prompt
   PS1="\[$sexy_bash_prompt_reset\]"
+
+  # Build out our non-git section (e.g. "todd at Euclid in ~/github/sexy-bash-prompt")
   PS1="$PS1\[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_preposition_color\]at\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_device_color\]\h\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_preposition_color\]in\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_dir_color\]\w\[$sexy_bash_prompt_reset\]"
+
+  # If we're in a git repo, then add in git-specific content (e.g. "on master*")
   if sexy_bash_prompt_is_on_git; then
     PS1="$PS1 \[$sexy_bash_prompt_preposition_color\]on\[$sexy_bash_prompt_reset\] "
     PS1="$PS1\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -257,8 +257,12 @@ sexy_bash_prompt_get_git_info () {
   fi
 }
 
+exit_code_test () {
+  echo "$*"
+}
+
 # Define the sexy-bash-prompt
-PS1="\[$sexy_bash_prompt_reset\]\
+PS1="\$(exit_code_test $?)\[$sexy_bash_prompt_reset\]\
 \[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] \
 \[$sexy_bash_prompt_preposition_color\]at\[$sexy_bash_prompt_reset\] \
 \[$sexy_bash_prompt_device_color\]\h\[$sexy_bash_prompt_reset\] \

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -257,20 +257,20 @@ sexy_bash_prompt_get_git_info () {
   fi
 }
 
-exit_code_test () {
-  echo "$*"
+sexy_bash_prompt_command () {
+  PS1="$?\[$sexy_bash_prompt_reset\]\
+  \[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] \
+  \[$sexy_bash_prompt_preposition_color\]at\[$sexy_bash_prompt_reset\] \
+  \[$sexy_bash_prompt_device_color\]\h\[$sexy_bash_prompt_reset\] \
+  \[$sexy_bash_prompt_preposition_color\]in\[$sexy_bash_prompt_reset\] \
+  \[$sexy_bash_prompt_dir_color\]\w\[$sexy_bash_prompt_reset\]\
+  \$( sexy_bash_prompt_is_on_git && \
+    echo -n \" \[$sexy_bash_prompt_preposition_color\]on\[$sexy_bash_prompt_reset\] \" && \
+    echo -n \"\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)\" && \
+    echo -n \"\[$sexy_bash_prompt_git_progress_color\]\$(sexy_bash_prompt_get_git_progress)\" && \
+    echo -n \"\[$sexy_bash_prompt_reset\]\")\n\
+  \[$sexy_bash_prompt_symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
 }
 
 # Define the sexy-bash-prompt
-PS1="\$(exit_code_test $?)\[$sexy_bash_prompt_reset\]\
-\[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] \
-\[$sexy_bash_prompt_preposition_color\]at\[$sexy_bash_prompt_reset\] \
-\[$sexy_bash_prompt_device_color\]\h\[$sexy_bash_prompt_reset\] \
-\[$sexy_bash_prompt_preposition_color\]in\[$sexy_bash_prompt_reset\] \
-\[$sexy_bash_prompt_dir_color\]\w\[$sexy_bash_prompt_reset\]\
-\$( sexy_bash_prompt_is_on_git && \
-  echo -n \" \[$sexy_bash_prompt_preposition_color\]on\[$sexy_bash_prompt_reset\] \" && \
-  echo -n \"\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)\" && \
-  echo -n \"\[$sexy_bash_prompt_git_progress_color\]\$(sexy_bash_prompt_get_git_progress)\" && \
-  echo -n \"\[$sexy_bash_prompt_reset\]\")\n\
-\[$sexy_bash_prompt_symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
+PROMPT_COMMAND=sexy_bash_prompt_command

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,8 @@ script:
   # - make test-install # Run install-specific test
 
 notifications:
-  email: false
+  email:
+    recipients:
+      - todd@twolfson.com
+    on_success: change
+    on_failure: change

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -271,7 +271,7 @@ esc=$'\033'
     # test "$sexy_bash_prompt_user_color" = "$esc[1m$esc[38;5;27m" || echo '`sexy_bash_prompt_user_color` is not bold blue (256)' 1>&2
 
     # uses 256 color palette
-    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
+    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
     expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
 
     # DEV: To debug, use a diff tool. Don't stare at the code.
@@ -286,7 +286,7 @@ esc=$'\033'
   $PROMPT_COMMAND
 
     # uses 8 color palette
-    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[34m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[36m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[32m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
+    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[34m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[36m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[32m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[33m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[31m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (8)' 1>&2
 
   # in an ANSI terminal
@@ -294,7 +294,7 @@ esc=$'\033'
   $PROMPT_COMMAND
 
     # uses ANSI colors
-    expected_prompt='\[\033[m\]\[\033[1;34m\]\u\[\033[m\] \[\033[1;37m\]at\[\033[m\] \[\033[1;36m\]\h\[\033[m\] \[\033[1;37m\]in\[\033[m\] \[\033[1;32m\]\w\[\033[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;37m\]on\[\033[m\] " &&   echo -n "\[\033[1;33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\[\033[m\]")\n\[\]$ \[\033[m\]'
+    expected_prompt='\[\033[m\]\[\033[1;34m\]\u\[\033[m\] \[\033[1;37m\]at\[\033[m\] \[\033[1;36m\]\h\[\033[m\] \[\033[1;37m\]in\[\033[m\] \[\033[1;32m\]\w\[\033[m\] \[\033[1;37m\]on\[\033[m\] \[\033[1;33m\]$(sexy_bash_prompt_get_git_info)\[\033[1;31m\]$(sexy_bash_prompt_get_git_progress)\[\033[m\]\n\[\]$ \[\033[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (ANSI)' 1>&2
 
   # when overridden
@@ -306,7 +306,7 @@ esc=$'\033'
   $PROMPT_COMMAND
 
     # use the new colors
-    expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;33m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\[\033[1;36m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[\033[1;38m\]$ \['$esc'(B'$esc'[m\]'
+    expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\] \[\033[1;33m\]on\['$esc'(B'$esc'[m\] \[\033[1;36m\]$(sexy_bash_prompt_get_git_info)\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\[\033[1;38m\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (overridden)' 1>&2
 
 # prompt status symbols

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -264,6 +264,7 @@ esc=$'\033'
 
   # in a 256 color terminal
   TERM=xterm-256color . .bash_prompt
+  $PROMPT_COMMAND
 
     # Deprecated color by color test, not used because requires double maintenance
     # echo "$(TERM=xterm-256color tput bold)$(TERM=xterm-256color tput setaf 27)" | copy
@@ -281,6 +282,7 @@ esc=$'\033'
 
   # in an 8 color terminal
   TERM=xterm . .bash_prompt
+  $PROMPT_COMMAND
 
     # uses 8 color palette
     expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[34m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[36m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[32m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
@@ -288,6 +290,7 @@ esc=$'\033'
 
   # in an ANSI terminal
   TERM="" . .bash_prompt
+  $PROMPT_COMMAND
 
     # uses ANSI colors
     expected_prompt='\[\033[m\]\[\033[1;34m\]\u\[\033[m\] \[\033[1;37m\]at\[\033[m\] \[\033[1;36m\]\h\[\033[m\] \[\033[1;37m\]in\[\033[m\] \[\033[1;32m\]\w\[\033[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;37m\]on\[\033[m\] " &&   echo -n "\[\033[1;33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\[\033[m\]")\n\[\]$ \[\033[m\]'
@@ -299,6 +302,7 @@ esc=$'\033'
     PROMPT_DIR_COLOR='\033[1;35m' PROMPT_GIT_STATUS_COLOR='\033[1;36m'  \
     PROMPT_GIT_PROGRESS_COLOR='\033[1;37m' PROMPT_SYMBOL_COLOR='\033[1;38m' \
     . .bash_prompt
+  $PROMPT_COMMAND
 
     # use the new colors
     expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;33m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\[\033[1;36m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[\033[1;38m\]$ \['$esc'(B'$esc'[m\]'
@@ -312,6 +316,7 @@ esc=$'\033'
     PROMPT_UNPUSHED_UNPULLED_SYMBOL='#unpushed-unpulled' PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL='#dirty-unpushed-unpulled' \
     PROMPT_SYMBOL='#prompt-symbol' \
     . .bash_prompt
+  $PROMPT_COMMAND
 
     # the prompt always uses the PROMPT_SYMBOL
     test "$sexy_bash_prompt_symbol" = "#prompt-symbol" || echo 'sexy_bash_prompt_symbol was not overridden by PROMPT_SYMBOL as expected' 1>&2

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -272,6 +272,7 @@ esc=$'\033'
 
     # uses 256 color palette
     expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
+    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
 
     # DEV: To debug, use a diff tool. Don't stare at the code.
     # http://www.diffchecker.com/diff

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -272,7 +272,6 @@ esc=$'\033'
 
     # uses 256 color palette
     expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
-    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
 
     # DEV: To debug, use a diff tool. Don't stare at the code.
     # http://www.diffchecker.com/diff


### PR DESCRIPTION
For #82, we needed to transition to `PROMPT_COMMAND` to properly capture the exit code of our last command. This will build out an updated `PS1` to use for our prompt

The transition was straightforward for the prompt but a bit rocky for testing. To minimize PR noise, I figured we should break it out into its own PR

In this PR:

- Moved from `PS1` to `PROMPT_COMMAND` which sets new `PS1`
- Updated tests
- Added email notifications for status change in Travis CI

Notes:

For reference, here's the `man` page that confirms we're using `PROMPT_COMMAND` correctly, https://archive.vn/4HsIg#selection-5444.0-5444.2
> If set, the value is executed as a command prior to issuing each primary prompt.

On previous attempts, I looked at blogs like this which dynamically echo'd out the prompt itself which was strange UX and felt off

https://tldp.org/HOWTO/Bash-Prompt-HOWTO/x264.html