### PR TITLE
Added exit code support

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -266,7 +266,6 @@ sexy_bash_prompt_command () {
   # https://gist.github.com/weibeld/f3b6e6187029924a9b3d
   # DEV: Use `local` to prevent contaminating scope outside of `PROMPT_COMMAND`
   local exit_code="$?"
-  echo "$exit_code"
 
   # If the last command has not changed (including its timestamp), then ignore our exit code
   # DEV: This is a personal preference around seeing a red $ on any failing command consistently
@@ -275,9 +274,8 @@ sexy_bash_prompt_command () {
   # last_command="501  2020-08-19T14:25:09-0700 echo hi"
   local last_command="$(history 1)"
   if [[ "$sexy_bash_prompt_last_command" == "$last_command" ]]; then
-    : # exit_code="0"
+    exit_code="0"
   fi
-  echo "$exit_code BB"
   sexy_bash_prompt_last_command="$last_command"
 
   # Reset our PS1 prompt

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -287,7 +287,7 @@ sexy_bash_prompt_command () {
 
   # Determine our symbol color
   local symbol_color="$sexy_bash_prompt_symbol_color"
-  if [[ "$exit_code" != "0" ]]; then
+  if [[ "$exit_code" != 0 ]]; then
     symbol_color="$sexy_bash_prompt_symbol_error_color"
   fi
   PS1="$PS1\[$symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -259,12 +259,22 @@ sexy_bash_prompt_get_git_info () {
   fi
 }
 
+sexy_bash_prompt_last_command=""
 sexy_bash_prompt_command () {
   # Pull down exit code before anything else (otherwise unsets it)
   # https://stackoverflow.com/a/16715681
   # https://gist.github.com/weibeld/f3b6e6187029924a9b3d
   # DEV: Use `local` to prevent contaminating scope outside of `PROMPT_COMMAND`
   local exit_code="$?"
+
+  # If the last command has not changed, then ignore our exit code
+  # DEV: This is a personal preference around seeing a red $ on any failing command consistently
+  # 501  2020-08-19T14:25:09-0700 echo hi
+  local last_command="$(history 1)"
+  if [[ "$sexy_bash_prompt_last_command" == "$last_command" ]]; then
+    exit_code="0"
+  fi
+  sexy_bash_prompt_last_command="$last_command"
 
   # Reset our PS1 prompt
   PS1="\[$sexy_bash_prompt_reset\]"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -99,6 +99,13 @@ if [[ -n "$PROMPT_DIRTY_UNPULLED_SYMBOL" ]]; then sexy_bash_prompt_dirty_unpulle
 if [[ -n "$PROMPT_UNPUSHED_UNPULLED_SYMBOL" ]]; then sexy_bash_prompt_unpushed_unpulled_symbol="$PROMPT_UNPUSHED_UNPULLED_SYMBOL"; fi
 if [[ -n "$PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL" ]]; then sexy_bash_prompt_dirty_unpushed_unpulled_symbol="$PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL"; fi
 
+# Set up configuration options
+sexy_bash_prompt_same_prompt_on_missing_command="0"
+
+# Apply configuration overrides that have been set in the environment
+if [[ -n "$PROMPT_SAME_PROMPT_ON_MISSING_COMMAND" ]]; then sexy_bash_prompt_same_prompt_on_missing_command="$PROMPT_SAME_PROMPT_ON_MISSING_COMMAND"; fi
+
+# Define all our helper functions
 function sexy_bash_prompt_get_git_branch() {
   # On branches, this will return the branch name
   # On non-branches, (no branch)
@@ -267,16 +274,23 @@ sexy_bash_prompt_command () {
   # DEV: Use `local` to prevent contaminating scope outside of `PROMPT_COMMAND`
   local exit_code="$?"
 
-  # If the last command has not changed (including its timestamp), then ignore our exit code
-  # DEV: This is a personal preference around seeing a red $ on any failing command consistently
-  # DEV: This also works to ignore keyboard interrupts in the prompt itself (normally exit code 130)
-  #   This will respect keyboard interrupt in running programs though (e.g. `time cat`)
-  # last_command="501  2020-08-19T14:25:09-0700 echo hi"
-  local last_command="$(history 1)"
-  if [[ "$sexy_bash_prompt_last_command" == "$last_command" ]]; then
-    exit_code="0"
+  # If we'd like to keep the prompt the same until there's a new command, then do nothing (default behavior)
+  # DEV: Double negatives can be confusing (e.g. `missing` + `!=`, `ignore` + `missing`) so we're avoiding them
+  if [[ "$sexy_bash_prompt_same_prompt_on_missing_command" == "1" ]];
+    : # No-op
+  # Otherwise, check if there's a new command/not
+  else
+    # If the last command has not changed (including its timestamp), then ignore our exit code
+    # DEV: This is a personal preference around seeing a red $ on any failing command consistently
+    # DEV: This also works to ignore keyboard interrupts in the prompt itself (normally exit code 130)
+    #   This will respect keyboard interrupt in running programs though (e.g. `time cat`)
+    # last_command="501  2020-08-19T14:25:09-0700 echo hi"
+    local last_command="$(history 1)"
+    if [[ "$sexy_bash_prompt_last_command" == "$last_command" ]]; then
+      exit_code="0"
+    fi
+    sexy_bash_prompt_last_command="$last_command"
   fi
-  sexy_bash_prompt_last_command="$last_command"
 
   # Reset our PS1 prompt
   PS1="\[$sexy_bash_prompt_reset\]"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -267,9 +267,11 @@ sexy_bash_prompt_command () {
   # DEV: Use `local` to prevent contaminating scope outside of `PROMPT_COMMAND`
   local exit_code="$?"
 
-  # If the last command has not changed, then ignore our exit code
+  # If the last command has not changed (including its timestamp), then ignore our exit code
   # DEV: This is a personal preference around seeing a red $ on any failing command consistently
-  # 501  2020-08-19T14:25:09-0700 echo hi
+  # DEV: This also works to ignore keyboard interrupts in the prompt itself (normally exit code 130)
+  #   This will respect keyboard interrupt in running programs though (e.g. `time cat`)
+  # last_command="501  2020-08-19T14:25:09-0700 echo hi"
   local last_command="$(history 1)"
   if [[ "$sexy_bash_prompt_last_command" == "$last_command" ]]; then
     exit_code="0"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -99,11 +99,11 @@ if [[ -n "$PROMPT_DIRTY_UNPULLED_SYMBOL" ]]; then sexy_bash_prompt_dirty_unpulle
 if [[ -n "$PROMPT_UNPUSHED_UNPULLED_SYMBOL" ]]; then sexy_bash_prompt_unpushed_unpulled_symbol="$PROMPT_UNPUSHED_UNPULLED_SYMBOL"; fi
 if [[ -n "$PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL" ]]; then sexy_bash_prompt_dirty_unpushed_unpulled_symbol="$PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL"; fi
 
-# Set up configuration options
-sexy_bash_prompt_same_prompt_on_missing_command="0"
+# Set up behavior options
+sexy_bash_prompt_show_error_once="1"
 
-# Apply configuration overrides that have been set in the environment
-if [[ -n "$PROMPT_SAME_PROMPT_ON_MISSING_COMMAND" ]]; then sexy_bash_prompt_same_prompt_on_missing_command="$PROMPT_SAME_PROMPT_ON_MISSING_COMMAND"; fi
+# Apply behavior overrides that have been set in the environment
+if [[ -n "$PROMPT_SHOW_ERROR_ONCE" ]]; then sexy_bash_prompt_show_error_once="$PROMPT_SHOW_ERROR_ONCE"; fi
 
 # Define all our helper functions
 function sexy_bash_prompt_get_git_branch() {
@@ -274,16 +274,12 @@ sexy_bash_prompt_command () {
   # DEV: Use `local` to prevent contaminating scope outside of `PROMPT_COMMAND`
   local exit_code="$?"
 
-  # If we'd like to keep the prompt the same until there's a new command, then do nothing (default behavior)
-  # DEV: Double negatives can be confusing (e.g. `missing` + `!=`, `ignore` + `missing`) so we're avoiding them
-  if [[ "$sexy_bash_prompt_same_prompt_on_missing_command" == "1" ]];
-    : # No-op
-  # Otherwise, check if there's a new command/not
-  else
+  # If we'd like to show errors once, then inspect further
+  # DEV: This is a personal preference around seeing a red $ on any failing command consistently
+  # DEV: This also works to ignore keyboard interrupts in the prompt itself (normally exit code 130)
+  #   This will respect keyboard interrupt in running programs though (e.g. `time cat`)
+  if [[ "$sexy_bash_prompt_show_error_once" == "1" ]]; then
     # If the last command has not changed (including its timestamp), then ignore our exit code
-    # DEV: This is a personal preference around seeing a red $ on any failing command consistently
-    # DEV: This also works to ignore keyboard interrupts in the prompt itself (normally exit code 130)
-    #   This will respect keyboard interrupt in running programs though (e.g. `time cat`)
     # last_command="501  2020-08-19T14:25:09-0700 echo hi"
     local last_command="$(history 1)"
     if [[ "$sexy_bash_prompt_last_command" == "$last_command" ]]; then

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -288,7 +288,7 @@ sexy_bash_prompt_command () {
   # Determine our symbol color
   local symbol_color="$sexy_bash_prompt_symbol_color"
   if [[ "$exit_code" != "0" ]]; then
-    symbol_color="$sexy_bash_prompt_symbol_error_color($exit_code)"
+    symbol_color="$sexy_bash_prompt_symbol_error_color"
   fi
   PS1="$PS1\[$symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
 }

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -288,7 +288,7 @@ sexy_bash_prompt_command () {
   # Determine our symbol color
   local symbol_color="$sexy_bash_prompt_symbol_color"
   if [[ "$exit_code" != "0" ]]; then
-    symbol_color="$sexy_bash_prompt_symbol_error_color"
+    symbol_color="$sexy_bash_prompt_symbol_error_color($exit_code)"
   fi
   PS1="$PS1\[$symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
 }

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -266,6 +266,7 @@ sexy_bash_prompt_command () {
   # https://gist.github.com/weibeld/f3b6e6187029924a9b3d
   # DEV: Use `local` to prevent contaminating scope outside of `PROMPT_COMMAND`
   local exit_code="$?"
+  echo "$exit_code"
 
   # If the last command has not changed (including its timestamp), then ignore our exit code
   # DEV: This is a personal preference around seeing a red $ on any failing command consistently
@@ -274,8 +275,9 @@ sexy_bash_prompt_command () {
   # last_command="501  2020-08-19T14:25:09-0700 echo hi"
   local last_command="$(history 1)"
   if [[ "$sexy_bash_prompt_last_command" == "$last_command" ]]; then
-    exit_code="0"
+    : # exit_code="0"
   fi
+  echo "$exit_code BB"
   sexy_bash_prompt_last_command="$last_command"
 
   # Reset our PS1 prompt

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -37,7 +37,7 @@ if tput setaf 1 &> /dev/null; then
   fi
 
   sexy_bash_prompt_symbol_color="$sexy_bash_prompt_bold" # BOLD
-
+  sexy_bash_prompt_symbol_error_color="$sexy_bash_prompt_bold$(tput setaf 1)" # BOLD RED
 else
 # Otherwise, use ANSI escape sequences for coloring
   # If you would like to customize your colors, use
@@ -55,6 +55,7 @@ else
   sexy_bash_prompt_git_status_color="\033[1;33m" # YELLOW
   sexy_bash_prompt_git_progress_color="\033[1;31m" # RED
   sexy_bash_prompt_symbol_color="" # NORMAL
+  sexy_bash_prompt_symbol_error_color="\033[1;31m" # RED
 fi
 
 # Define the default prompt terminator character '$'
@@ -73,6 +74,7 @@ if [[ -n "$PROMPT_GIT_STATUS_COLOR" ]]; then sexy_bash_prompt_git_status_color="
 if [[ -n "$PROMPT_GIT_PROGRESS_COLOR" ]]; then sexy_bash_prompt_git_progress_color="$PROMPT_GIT_PROGRESS_COLOR"; fi
 if [[ -n "$PROMPT_SYMBOL" ]]; then sexy_bash_prompt_symbol="$PROMPT_SYMBOL"; fi
 if [[ -n "$PROMPT_SYMBOL_COLOR" ]]; then sexy_bash_prompt_symbol_color="$PROMPT_SYMBOL_COLOR"; fi
+if [[ -n "$PROMPT_SYMBOL_ERROR_COLOR" ]]; then sexy_bash_prompt_symbol_error_color="$PROMPT_SYMBOL_ERROR_COLOR"; fi
 
 # Set up symbols
 sexy_bash_prompt_synced_symbol=""
@@ -261,15 +263,20 @@ sexy_bash_prompt_command () {
   # Pull down exit code before anything else (otherwise unsets it)
   # https://stackoverflow.com/a/16715681
   # https://gist.github.com/weibeld/f3b6e6187029924a9b3d
-  exit_code="$?"
+  # DEV: Use `local` to prevent contaminating scope outside of `PROMPT_COMMAND`
+  local exit_code="$?"
 
-  # Reset our PS1 prompt and start building it up
+  # Reset our PS1 prompt
   PS1="\[$sexy_bash_prompt_reset\]"
+
+  # Build out our non-git section (e.g. "todd at Euclid in ~/github/sexy-bash-prompt")
   PS1="$PS1\[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_preposition_color\]at\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_device_color\]\h\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_preposition_color\]in\[$sexy_bash_prompt_reset\] "
   PS1="$PS1\[$sexy_bash_prompt_dir_color\]\w\[$sexy_bash_prompt_reset\]"
+
+  # If we're in a git repo, then add in git-specific content (e.g. "on master*")
   if sexy_bash_prompt_is_on_git; then
     PS1="$PS1 \[$sexy_bash_prompt_preposition_color\]on\[$sexy_bash_prompt_reset\] "
     PS1="$PS1\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)"
@@ -277,7 +284,13 @@ sexy_bash_prompt_command () {
     PS1="$PS1\[$sexy_bash_prompt_reset\]"
   fi
   PS1="$PS1\n"
-  PS1="$PS1\[$sexy_bash_prompt_symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
+
+  # Determine our symbol color
+  local symbol_color="$sexy_bash_prompt_symbol_color"
+  if [[ "$exit_code" != "0" ]]; then
+    symbol_color="$sexy_bash_prompt_symbol_error_color"
+  fi
+  PS1="$PS1\[$symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
 }
 
 # Define the sexy-bash-prompt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,8 @@ script:
   # - make test-install # Run install-specific test
 
 notifications:
-  email: false
+  email:
+    recipients:
+      - todd@twolfson.com
+    on_success: change
+    on_failure: change

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL="*↑↓"
 ```
 
 ## How does it work?
-[bash][bash] provides a special set of [variables for your prompts][ps-vars]. `PS1` is the one used by default. The install script adds a command to `~/.bashrc`, a file that is run every time a new terminal opens. Inside of the new command, we run our script and set your `PS1` which runs some `git` commands to determine its current state and outputs them as a string.
+[bash][bash] provides a special set of [variables for your prompts][ps-vars]. `PS1` is the one used by default. The install script adds a command to `~/.bashrc`, a file that is run every time a new terminal opens. Inside of the new command, we run our script and set your `PROMPT_COMMAND` and `PS1` which runs some `git` commands to determine its current state and outputs them as a string.
 
 [bash]: https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29
 [ps-vars]: http://www.gnu.org/software/bash/manual/bashref.html#index-PS1

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ Colors can be customized by editing `.bash_prompt` directly, or by setting the f
 - `PROMPT_DIR_COLOR` - Color for directory (e.g. `~/github/sexy-bash-prompt`)
 - `PROMPT_GIT_STATUS_COLOR` - Color for git branch and symbol (e.g. `master`)
 - `PROMPT_GIT_PROGRESS_COLOR` - Color for in progress git actions (e.g. `[merge]`)
-- `PROMPT_SYMBOL_COLOR` - Color for prompt symbol (e.g. `$`)
+- `PROMPT_SYMBOL_COLOR` - Color for prompt symbol by default or on success (e.g. `$`)
+- `PROMPT_SYMBOL_ERROR_COLOR` - Color for prompt symbol on error (e.g. `$`)
 
 You can set colors via [`tput`][] or [ANSI escape codes][]. For example:
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ source ~/.bashrc
 ```
 
 ## Configuration
+### Behavior
+Behavior can be customized with the following environment variables:
+
+- `PROMPT_SAME_PROMPT_COLOR_ON_MISSING_COMMAND` - If the
+  - `bash` will persist the previous exit code on any missing command (e.g. comment line only, keyboard interrupt, empty command)
+  - Setting to `0` means only show error status for any new command, `1` means show it until overridden by a new command
+  - This behavior doesn't alter the exit code, only the prompt symbol color
+
 ### Colors
 Colors can be customized by editing `.bash_prompt` directly, or by setting the following environment variables:
 

--- a/README.md
+++ b/README.md
@@ -143,10 +143,9 @@ source ~/.bashrc
 ### Behavior
 Behavior can be customized with the following environment variables:
 
-- `PROMPT_SAME_PROMPT_COLOR_ON_MISSING_COMMAND` - If the
-  - `bash` will persist the previous exit code on any missing command (e.g. comment line only, keyboard interrupt, empty command)
-  - Setting to `0` means only show error status for any new command, `1` means show it until overridden by a new command
-  - This behavior doesn't alter the exit code, only the prompt symbol color
+- `PROMPT_SHOW_ERROR_ONCE` - If enabled (default), then will only show error color once per command execution
+  - `bash` persists a non-zero exit code across missing commands (e.g. comment line only, keyboard interrupt, empty command)
+  - Setting this to `1` (default) means show error status once, `0` means always show same error status until a new command is executed
 
 ### Colors
 Colors can be customized by editing `.bash_prompt` directly, or by setting the following environment variables:

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -264,6 +264,7 @@ esc=$'\033'
 
   # in a 256 color terminal
   TERM=xterm-256color . .bash_prompt
+  $PROMPT_COMMAND
 
     # Deprecated color by color test, not used because requires double maintenance
     # echo "$(TERM=xterm-256color tput bold)$(TERM=xterm-256color tput setaf 27)" | copy
@@ -281,6 +282,7 @@ esc=$'\033'
 
   # in an 8 color terminal
   TERM=xterm . .bash_prompt
+  $PROMPT_COMMAND
 
     # uses 8 color palette
     expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[34m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[36m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[32m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
@@ -288,6 +290,7 @@ esc=$'\033'
 
   # in an ANSI terminal
   TERM="" . .bash_prompt
+  $PROMPT_COMMAND
 
     # uses ANSI colors
     expected_prompt='\[\033[m\]\[\033[1;34m\]\u\[\033[m\] \[\033[1;37m\]at\[\033[m\] \[\033[1;36m\]\h\[\033[m\] \[\033[1;37m\]in\[\033[m\] \[\033[1;32m\]\w\[\033[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;37m\]on\[\033[m\] " &&   echo -n "\[\033[1;33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\[\033[m\]")\n\[\]$ \[\033[m\]'
@@ -299,6 +302,7 @@ esc=$'\033'
     PROMPT_DIR_COLOR='\033[1;35m' PROMPT_GIT_STATUS_COLOR='\033[1;36m'  \
     PROMPT_GIT_PROGRESS_COLOR='\033[1;37m' PROMPT_SYMBOL_COLOR='\033[1;38m' \
     . .bash_prompt
+  $PROMPT_COMMAND
 
     # use the new colors
     expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;33m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\[\033[1;36m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[\033[1;38m\]$ \['$esc'(B'$esc'[m\]'
@@ -312,6 +316,7 @@ esc=$'\033'
     PROMPT_UNPUSHED_UNPULLED_SYMBOL='#unpushed-unpulled' PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL='#dirty-unpushed-unpulled' \
     PROMPT_SYMBOL='#prompt-symbol' \
     . .bash_prompt
+  $PROMPT_COMMAND
 
     # the prompt always uses the PROMPT_SYMBOL
     test "$sexy_bash_prompt_symbol" = "#prompt-symbol" || echo 'sexy_bash_prompt_symbol was not overridden by PROMPT_SYMBOL as expected' 1>&2

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -311,12 +311,12 @@ esc=$'\033'
   # with an error code
   TERM=xterm-256color . .bash_prompt
   # DEV: Stub out last command being checked against
-  sexy_bash_prompt_last_command=""
+  sexy_bash_prompt_last_command="invalid command"
   false
   $PROMPT_COMMAND
 
     # uses red prompt symbol
-    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
+    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m'$esc'[31m\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (error-code)' 1>&2
 
 # prompt status symbols

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -308,6 +308,17 @@ esc=$'\033'
     expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\] \[\033[1;33m\]on\['$esc'(B'$esc'[m\] \[\033[1;36m\]$(sexy_bash_prompt_get_git_info)\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\[\033[1;38m\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (overridden)' 1>&2
 
+  # with an error code
+  TERM=xterm-256color . .bash_prompt
+  # DEV: Stub out last command being checked against
+  sexy_bash_prompt_last_command=""
+  false
+  $PROMPT_COMMAND
+
+    # uses red prompt symbol
+    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
+    test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (error-code)' 1>&2
+
 # prompt status symbols
   # when overridden
   PROMPT_SYNCED_SYMBOL='#synced' PROMPT_DIRTY_SYNCED_SYMBOL='#dirty-synced' \


### PR DESCRIPTION
As per #82, we've wanted exit code support for a while and are finally adding it

We discovered the quirk that `bash` will persist exit codes until a new command is provided so we added a configuration to ignore that

In this PR:

- Added non-zero exit code support
- Added tests
- Added `PROMPT_SYMBOL_ERROR_COLOR` environment variable support for customization
- Added `PROMPT_SHOW_ERROR_ONCE` environment variable to allow opt-out of hiding persisted exit code
- Added documentation
- Depends on #88, don't land until that's landed (and then update this PR `base` to `master`)

Screenshots:

![Selection_218](https://user-images.githubusercontent.com/902488/90970393-43744f00-e4b9-11ea-9753-ebcceff58496.png)