### PR TITLE
Added back exit code support

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -323,4 +323,4 @@ PS1="\[$sexy_bash_prompt_reset\]\
   echo -n \"\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)\" && \
   echo -n \"\[$sexy_bash_prompt_git_progress_color\]\$(sexy_bash_prompt_get_git_progress)\" && \
   echo -n \"\[$sexy_bash_prompt_reset\]\")\n\
-\$(sexy_bash_prompt_get_symbol_color)$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
+\[\$(sexy_bash_prompt_get_symbol_color)\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -296,7 +296,7 @@ sexy_bash_prompt_command () {
 # DEV: Extend `PROMPT_COMMAND` if there already is one
 if [[ "$PROMPT_COMMAND" != "" ]]; then
   PROMPT_COMMAND="sexy_bash_prompt_command;$PROMPT_COMMAND"
-# else
+else
   PROMPT_COMMAND="sexy_bash_prompt_command"
 fi
 

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -37,7 +37,7 @@ if tput setaf 1 &> /dev/null; then
   fi
 
   sexy_bash_prompt_symbol_color="$sexy_bash_prompt_bold" # BOLD
-
+  sexy_bash_prompt_symbol_error_color="$sexy_bash_prompt_bold$(tput setaf 1)" # BOLD RED
 else
 # Otherwise, use ANSI escape sequences for coloring
   # If you would like to customize your colors, use
@@ -55,6 +55,7 @@ else
   sexy_bash_prompt_git_status_color="\033[1;33m" # YELLOW
   sexy_bash_prompt_git_progress_color="\033[1;31m" # RED
   sexy_bash_prompt_symbol_color="" # NORMAL
+  sexy_bash_prompt_symbol_error_color="\033[1;31m" # RED
 fi
 
 # Define the default prompt terminator character '$'
@@ -73,6 +74,7 @@ if [[ -n "$PROMPT_GIT_STATUS_COLOR" ]]; then sexy_bash_prompt_git_status_color="
 if [[ -n "$PROMPT_GIT_PROGRESS_COLOR" ]]; then sexy_bash_prompt_git_progress_color="$PROMPT_GIT_PROGRESS_COLOR"; fi
 if [[ -n "$PROMPT_SYMBOL" ]]; then sexy_bash_prompt_symbol="$PROMPT_SYMBOL"; fi
 if [[ -n "$PROMPT_SYMBOL_COLOR" ]]; then sexy_bash_prompt_symbol_color="$PROMPT_SYMBOL_COLOR"; fi
+if [[ -n "$PROMPT_SYMBOL_ERROR_COLOR" ]]; then sexy_bash_prompt_symbol_error_color="$PROMPT_SYMBOL_ERROR_COLOR"; fi
 
 # Set up symbols
 sexy_bash_prompt_synced_symbol=""
@@ -97,6 +99,13 @@ if [[ -n "$PROMPT_DIRTY_UNPULLED_SYMBOL" ]]; then sexy_bash_prompt_dirty_unpulle
 if [[ -n "$PROMPT_UNPUSHED_UNPULLED_SYMBOL" ]]; then sexy_bash_prompt_unpushed_unpulled_symbol="$PROMPT_UNPUSHED_UNPULLED_SYMBOL"; fi
 if [[ -n "$PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL" ]]; then sexy_bash_prompt_dirty_unpushed_unpulled_symbol="$PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL"; fi
 
+# Set up behavior options
+sexy_bash_prompt_show_error_once="1"
+
+# Apply behavior overrides that have been set in the environment
+if [[ -n "$PROMPT_SHOW_ERROR_ONCE" ]]; then sexy_bash_prompt_show_error_once="$PROMPT_SHOW_ERROR_ONCE"; fi
+
+# Define all our helper functions
 function sexy_bash_prompt_get_git_branch() {
   # On branches, this will return the branch name
   # On non-branches, (no branch)
@@ -289,6 +298,7 @@ sexy_bash_prompt_get_symbol_color () {
 }
 
 # Define our hooks for storing the exit code
+sexy_bash_prompt_last_command=""
 sexy_bash_prompt_command () {
   export sexy_bash_prompt_exit_code="$?"
 }

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -264,7 +264,6 @@ sexy_bash_prompt_store_exit_code () {
 }
 sexy_bash_prompt_get_symbol_color () {
   echo "$sexy_bash_prompt_exit_code"
-  echo "foo"
 }
 # DEV: Extend `PROMPT_COMMAND` if there already is one
 if [[ "$PROMPT_COMMAND" != "" ]]; then
@@ -285,4 +284,4 @@ PS1="\[$sexy_bash_prompt_reset\]\
   echo -n \"\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)\" && \
   echo -n \"\[$sexy_bash_prompt_git_progress_color\]\$(sexy_bash_prompt_get_git_progress)\" && \
   echo -n \"\[$sexy_bash_prompt_reset\]\")\n\
-$(sexy_bash_prompt_get_symbol_color)$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
+\$(sexy_bash_prompt_get_symbol_color)$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -304,6 +304,8 @@ sexy_bash_prompt_command () {
   # DEV: We would save these in `get_symbol_color` but its subshell variables don't persist
   export sexy_bash_prompt_last_command="$sexy_bash_prompt_current_command"
   export sexy_bash_prompt_current_command="$(history 1)"
+
+  # DEV: We don't set PS1 in here as it would prevent extension, see https://github.com/twolfson/sexy-bash-prompt/issues/90
 }
 # DEV: Extend `PROMPT_COMMAND` if there already is one
 if [[ "$PROMPT_COMMAND" != "" ]]; then

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -279,14 +279,13 @@ sexy_bash_prompt_get_symbol_color () {
   # DEV: This is a personal preference around seeing a red $ on any failing command consistently
   # DEV: This also works to ignore keyboard interrupts in the prompt itself (normally exit code 130)
   #   This will respect keyboard interrupt in running programs though (e.g. `time cat`)
+  # DEV: Further explanation of all scenarios, https://github.com/twolfson/sexy-bash-prompt/pull/89#issuecomment-685239313
   if [[ "$sexy_bash_prompt_show_error_once" == "1" ]]; then
     # If the last command has not changed (including its timestamp), then ignore our exit code
-    # last_command="501  2020-08-19T14:25:09-0700 echo hi"
-    local last_command="$(history 1)"
-    if [[ "$sexy_bash_prompt_last_command" == "$last_command" ]]; then
+    # last_command="501  echo hi"
+    if [[ "$sexy_bash_prompt_last_command" == "$sexy_bash_prompt_current_command" ]]; then
       exit_code="0"
     fi
-    sexy_bash_prompt_last_command="$last_command"
   fi
 
   # Determine and output our symbol color
@@ -297,10 +296,13 @@ sexy_bash_prompt_get_symbol_color () {
   echo "$symbol_color"
 }
 
-# Define our hooks for storing the exit code
-sexy_bash_prompt_last_command=""
+# Define our hooks for storing the exit code and past commands
+sexy_bash_prompt_current_command=""
 sexy_bash_prompt_command () {
   export sexy_bash_prompt_exit_code="$?"
+  # DEV: We would save these in `get_symbol_color` but its subshell variables don't persist
+  export sexy_bash_prompt_last_command="$sexy_bash_prompt_current_command"
+  export sexy_bash_prompt_current_command="$(history 1)"
 }
 # DEV: Extend `PROMPT_COMMAND` if there already is one
 if [[ "$PROMPT_COMMAND" != "" ]]; then

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -271,6 +271,7 @@ sexy_bash_prompt_get_symbol_color () {
   if [[ "$sexy_bash_prompt_exit_code" == "" ]]; then
     echo "Missing \`sexy_bash_prompt_exit_code\` for prompt symbol coloring" 1>&2
     echo "Please verify \`PROMPT_COMMAND\` includes \`sexy_bash_prompt_command\` (enabled unless overwritten)" 1>&2
+    echo "$sexy_bash_prompt_symbol_color"
     return
   fi
   exit_code="$sexy_bash_prompt_exit_code"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -257,19 +257,47 @@ sexy_bash_prompt_get_git_info () {
   fi
 }
 
+sexy_bash_prompt_get_symbol_color () {
+  # Verify we have an exit code set
+  # if [[ "$sexy_bash_prompt_exit_code" == "" ]]; then
+  #   echo "Missing \`sexy_bash_prompt_exit_code\` for prompt symbol coloring" 1>&2
+  #   echo "Please verify \`PROMPT_COMMAND\` includes an invocation for \`sexy_bash_prompt_command\` (enabled unless overwritten)" 1>&2
+  #   return
+  # fi
+  exit_code="$sexy_bash_prompt_exit_code"
+  echo "wat$exit_code"
+
+  # If we'd like to show errors once, then inspect further
+  # DEV: This is a personal preference around seeing a red $ on any failing command consistently
+  # DEV: This also works to ignore keyboard interrupts in the prompt itself (normally exit code 130)
+  #   This will respect keyboard interrupt in running programs though (e.g. `time cat`)
+  if [[ "$sexy_bash_prompt_show_error_once" == "1" ]]; then
+    # If the last command has not changed (including its timestamp), then ignore our exit code
+    # last_command="501  2020-08-19T14:25:09-0700 echo hi"
+    local last_command="$(history 1)"
+    if [[ "$sexy_bash_prompt_last_command" == "$last_command" ]]; then
+      exit_code="0"
+    fi
+    sexy_bash_prompt_last_command="$last_command"
+  fi
+
+  # Determine and output our symbol color
+  symbol_color="$sexy_bash_prompt_symbol_color"
+  if [[ "$exit_code" != 0 ]]; then
+    symbol_color="$sexy_bash_prompt_symbol_error_color"
+  fi
+  echo "$symbol_color"
+}
 
 # Define our hooks for storing the exit code
-sexy_bash_prompt_store_exit_code () {
+sexy_bash_prompt_command () {
   export sexy_bash_prompt_exit_code="$?"
-}
-sexy_bash_prompt_get_symbol_color () {
-  echo "$sexy_bash_prompt_exit_code"
 }
 # DEV: Extend `PROMPT_COMMAND` if there already is one
 if [[ "$PROMPT_COMMAND" != "" ]]; then
-  PROMPT_COMMAND="sexy_bash_prompt_store_exit_code;$PROMPT_COMMAND"
-else
-  PROMPT_COMMAND="sexy_bash_prompt_store_exit_code"
+  PROMPT_COMMAND="sexy_bash_prompt_command;$PROMPT_COMMAND"
+# else
+  PROMPT_COMMAND="sexy_bash_prompt_command"
 fi
 
 # Define the sexy-bash-prompt

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -306,7 +306,7 @@ sexy_bash_prompt_command () {
 }
 # DEV: Extend `PROMPT_COMMAND` if there already is one
 if [[ "$PROMPT_COMMAND" != "" ]]; then
-  PROMPT_COMMAND="sexy_bash_prompt_command;$PROMPT_COMMAND"
+  PROMPT_COMMAND="sexy_bash_prompt_command ; $PROMPT_COMMAND"
 else
   PROMPT_COMMAND="sexy_bash_prompt_command"
 fi

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -257,6 +257,22 @@ sexy_bash_prompt_get_git_info () {
   fi
 }
 
+
+# Define our hooks for storing the exit code
+sexy_bash_prompt_store_exit_code () {
+  export sexy_bash_prompt_exit_code="$?"
+}
+sexy_bash_prompt_get_symbol_color () {
+  echo "$sexy_bash_prompt_exit_code"
+  echo "foo"
+}
+# DEV: Extend `PROMPT_COMMAND` if there already is one
+if [[ "$PROMPT_COMMAND" != "" ]]; then
+  PROMPT_COMMAND="sexy_bash_prompt_store_exit_code;$PROMPT_COMMAND"
+else
+  PROMPT_COMMAND="sexy_bash_prompt_store_exit_code"
+fi
+
 # Define the sexy-bash-prompt
 PS1="\[$sexy_bash_prompt_reset\]\
 \[$sexy_bash_prompt_user_color\]\u\[$sexy_bash_prompt_reset\] \
@@ -269,4 +285,4 @@ PS1="\[$sexy_bash_prompt_reset\]\
   echo -n \"\[$sexy_bash_prompt_git_status_color\]\$(sexy_bash_prompt_get_git_info)\" && \
   echo -n \"\[$sexy_bash_prompt_git_progress_color\]\$(sexy_bash_prompt_get_git_progress)\" && \
   echo -n \"\[$sexy_bash_prompt_reset\]\")\n\
-\[$sexy_bash_prompt_symbol_color\]$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"
+$(sexy_bash_prompt_get_symbol_color)$sexy_bash_prompt_symbol \[$sexy_bash_prompt_reset\]"

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -259,13 +259,12 @@ sexy_bash_prompt_get_git_info () {
 
 sexy_bash_prompt_get_symbol_color () {
   # Verify we have an exit code set
-  # if [[ "$sexy_bash_prompt_exit_code" == "" ]]; then
-  #   echo "Missing \`sexy_bash_prompt_exit_code\` for prompt symbol coloring" 1>&2
-  #   echo "Please verify \`PROMPT_COMMAND\` includes an invocation for \`sexy_bash_prompt_command\` (enabled unless overwritten)" 1>&2
-  #   return
-  # fi
+  if [[ "$sexy_bash_prompt_exit_code" == "" ]]; then
+    echo "Missing \`sexy_bash_prompt_exit_code\` for prompt symbol coloring" 1>&2
+    echo "Please verify \`PROMPT_COMMAND\` includes \`sexy_bash_prompt_command\` (enabled unless overwritten)" 1>&2
+    return
+  fi
   exit_code="$sexy_bash_prompt_exit_code"
-  echo "wat$exit_code"
 
   # If we'd like to show errors once, then inspect further
   # DEV: This is a personal preference around seeing a red $ on any failing command consistently

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -300,7 +300,10 @@ sexy_bash_prompt_get_symbol_color () {
 # Define our hooks for storing the exit code and past commands
 sexy_bash_prompt_current_command=""
 sexy_bash_prompt_command () {
+  # Capture and expose exit code first before anything, otherwise it'll be lost
   export sexy_bash_prompt_exit_code="$?"
+
+  # Capture last commands for `SEXY_BASH_PROMPT_SHOW_ERROR_ONCE` logic
   # DEV: We would save these in `get_symbol_color` but its subshell variables don't persist
   export sexy_bash_prompt_last_command="$sexy_bash_prompt_current_command"
   export sexy_bash_prompt_current_command="$(history 1)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,8 @@ script:
   # - make test-install # Run install-specific test
 
 notifications:
-  email: false
+  email:
+    recipients:
+      - todd@twolfson.com
+    on_success: change
+    on_failure: change

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ source ~/.bashrc
 ```
 
 ## Configuration
+### Behavior
+Behavior can be customized with the following environment variables:
+
+- `PROMPT_SHOW_ERROR_ONCE` - If enabled (default), then will only show error color once per command execution
+  - `bash` persists a non-zero exit code across missing commands (e.g. comment line only, keyboard interrupt, empty command)
+  - Setting this to `1` (default) means show error status once, `0` means always show same error status until a new command is executed
+
 ### Colors
 Colors can be customized by editing `.bash_prompt` directly, or by setting the following environment variables:
 
@@ -149,7 +156,8 @@ Colors can be customized by editing `.bash_prompt` directly, or by setting the f
 - `PROMPT_DIR_COLOR` - Color for directory (e.g. `~/github/sexy-bash-prompt`)
 - `PROMPT_GIT_STATUS_COLOR` - Color for git branch and symbol (e.g. `master`)
 - `PROMPT_GIT_PROGRESS_COLOR` - Color for in progress git actions (e.g. `[merge]`)
-- `PROMPT_SYMBOL_COLOR` - Color for prompt symbol (e.g. `$`)
+- `PROMPT_SYMBOL_COLOR` - Color for prompt symbol by default or on success (e.g. `$`)
+- `PROMPT_SYMBOL_ERROR_COLOR` - Color for prompt symbol on error (e.g. `$`)
 
 You can set colors via [`tput`][] or [ANSI escape codes][]. For example:
 
@@ -201,7 +209,7 @@ PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL="*↑↓"
 ```
 
 ## How does it work?
-[bash][bash] provides a special set of [variables for your prompts][ps-vars]. `PS1` is the one used by default. The install script adds a command to `~/.bashrc`, a file that is run every time a new terminal opens. Inside of the new command, we run our script and set your `PS1` which runs some `git` commands to determine its current state and outputs them as a string.
+[bash][bash] provides a special set of [variables for your prompts][ps-vars]. `PS1` is the one used by default. The install script adds a command to `~/.bashrc`, a file that is run every time a new terminal opens. Inside of the new command, we run our script and set your `PROMPT_COMMAND` and `PS1` which runs some `git` commands to determine its current state and outputs them as a string.
 
 [bash]: https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29
 [ps-vars]: http://www.gnu.org/software/bash/manual/bashref.html#index-PS1

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -314,17 +314,27 @@ esc=$'\033'
     expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;33m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\[\033[1;36m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (overridden)' 1>&2
 
-  # with an error code
+# prompt symbol color
+  # when overridden
   PROMPT_COMMAND=""
-  TERM=xterm-256color . .bash_prompt
-  # DEV: Stub out last command being checked against
-  sexy_bash_prompt_last_command="invalid command"
-  false
-  $PROMPT_COMMAND
+  PROMPT_SYMBOL_COLOR='#default-color' PROMPT_ERROR_SYMBOL_COLOR='#error-color' \
+    . .bash_prompt
 
-    # uses red prompt symbol
-    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \['$esc'(B'$esc'[m\]'
-    test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (error-code)' 1>&2
+    # a successful command uses the default color
+    # DEV: Stub out last command being checked against
+    sexy_bash_prompt_last_command="valid command"
+    true
+    $PROMPT_COMMAND
+
+    test $(sexy_bash_prompt_get_symbol_color) = "#default-color" || echo 'sexy_bash_prompt_get_symbol_color did not return `#default-color` as expected' 1>&2
+
+    # an errored command uses the error color
+    # DEV: Stub out last command being checked against
+    sexy_bash_prompt_last_command="invalid command"
+    false
+    $PROMPT_COMMAND
+
+    test $(sexy_bash_prompt_get_symbol_color) = "#error-color" || echo 'sexy_bash_prompt_get_symbol_color did not return `#error-color` as expected' 1>&2
 
 # prompt status symbols
   # when overridden

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -264,6 +264,7 @@ esc=$'\033'
 
   # in a 256 color terminal
   TERM=xterm-256color . .bash_prompt
+  $PROMPT_COMMAND
 
     # Deprecated color by color test, not used because requires double maintenance
     # echo "$(TERM=xterm-256color tput bold)$(TERM=xterm-256color tput setaf 27)" | copy
@@ -281,6 +282,7 @@ esc=$'\033'
 
   # in an 8 color terminal
   TERM=xterm . .bash_prompt
+  $PROMPT_COMMAND
 
     # uses 8 color palette
     expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[34m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[36m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[32m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
@@ -288,6 +290,7 @@ esc=$'\033'
 
   # in an ANSI terminal
   TERM="" . .bash_prompt
+  $PROMPT_COMMAND
 
     # uses ANSI colors
     expected_prompt='\[\033[m\]\[\033[1;34m\]\u\[\033[m\] \[\033[1;37m\]at\[\033[m\] \[\033[1;36m\]\h\[\033[m\] \[\033[1;37m\]in\[\033[m\] \[\033[1;32m\]\w\[\033[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;37m\]on\[\033[m\] " &&   echo -n "\[\033[1;33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\[\033[m\]")\n\[\]$ \[\033[m\]'
@@ -299,10 +302,22 @@ esc=$'\033'
     PROMPT_DIR_COLOR='\033[1;35m' PROMPT_GIT_STATUS_COLOR='\033[1;36m'  \
     PROMPT_GIT_PROGRESS_COLOR='\033[1;37m' PROMPT_SYMBOL_COLOR='\033[1;38m' \
     . .bash_prompt
+  $PROMPT_COMMAND
 
     # use the new colors
     expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;33m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\[\033[1;36m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[\033[1;38m\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (overridden)' 1>&2
+
+  # with an error code
+  TERM=xterm-256color . .bash_prompt
+  # DEV: Stub out last command being checked against
+  sexy_bash_prompt_last_command="invalid command"
+  false
+  $PROMPT_COMMAND
+
+    # uses red prompt symbol
+    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m'$esc'[31m\]$ \['$esc'(B'$esc'[m\]'
+    test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (error-code)' 1>&2
 
 # prompt status symbols
   # when overridden
@@ -312,6 +327,7 @@ esc=$'\033'
     PROMPT_UNPUSHED_UNPULLED_SYMBOL='#unpushed-unpulled' PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL='#dirty-unpushed-unpulled' \
     PROMPT_SYMBOL='#prompt-symbol' \
     . .bash_prompt
+  $PROMPT_COMMAND
 
     # the prompt always uses the PROMPT_SYMBOL
     test "$sexy_bash_prompt_symbol" = "#prompt-symbol" || echo 'sexy_bash_prompt_symbol was not overridden by PROMPT_SYMBOL as expected' 1>&2

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -298,7 +298,7 @@ esc=$'\033'
   $PROMPT_COMMAND
 
     # uses ANSI colors
-    expected_prompt='\[\033[m\]\[\033[1;34m\]\u\[\033[m\] \[\033[1;37m\]at\[\033[m\] \[\033[1;36m\]\h\[\033[m\] \[\033[1;37m\]in\[\033[m\] \[\033[1;32m\]\w\[\033[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;37m\]on\[\033[m\] " &&   echo -n "\[\033[1;33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\[\033[m\]")\n\[\]$ \[\033[m\]'
+    expected_prompt='\[\033[m\]\[\033[1;34m\]\u\[\033[m\] \[\033[1;37m\]at\[\033[m\] \[\033[1;36m\]\h\[\033[m\] \[\033[1;37m\]in\[\033[m\] \[\033[1;32m\]\w\[\033[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;37m\]on\[\033[m\] " &&   echo -n "\[\033[1;33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\[\033[m\]")\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \[\033[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (ANSI)' 1>&2
 
   # when overridden

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -1,3 +1,6 @@
+# Enable history for accurate past command testing
+set -o history
+
 # Navigate to test directory
 ORIG_PWD="$PWD"
 TEST_DIR="$PWD/test"
@@ -323,16 +326,12 @@ esc=$'\033'
     # a successful command uses the default color
     true
     $PROMPT_COMMAND
-    # DEV: Stub out last command being checked against
-    sexy_bash_prompt_last_command="valid command"
 
     test $(sexy_bash_prompt_get_symbol_color) = "#default-color" || echo 'sexy_bash_prompt_get_symbol_color did not return `#default-color` as expected' 1>&2
 
     # an errored command uses the error color
     false
     $PROMPT_COMMAND
-    # DEV: Stub out last command being checked against
-    sexy_bash_prompt_last_command="invalid command"
 
     test $(sexy_bash_prompt_get_symbol_color) = "#error-color" || echo 'sexy_bash_prompt_get_symbol_color did not return `#error-color` as expected' 1>&2
 

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -317,22 +317,22 @@ esc=$'\033'
 # prompt symbol color
   # when overridden
   PROMPT_COMMAND=""
-  PROMPT_SYMBOL_COLOR='#default-color' PROMPT_ERROR_SYMBOL_COLOR='#error-color' \
+  PROMPT_SYMBOL_COLOR='#default-color' PROMPT_SYMBOL_ERROR_COLOR='#error-color' \
     . .bash_prompt
 
     # a successful command uses the default color
-    # DEV: Stub out last command being checked against
-    sexy_bash_prompt_last_command="valid command"
     true
     $PROMPT_COMMAND
+    # DEV: Stub out last command being checked against
+    sexy_bash_prompt_last_command="valid command"
 
     test $(sexy_bash_prompt_get_symbol_color) = "#default-color" || echo 'sexy_bash_prompt_get_symbol_color did not return `#default-color` as expected' 1>&2
 
     # an errored command uses the error color
-    # DEV: Stub out last command being checked against
-    sexy_bash_prompt_last_command="invalid command"
     false
     $PROMPT_COMMAND
+    # DEV: Stub out last command being checked against
+    sexy_bash_prompt_last_command="invalid command"
 
     test $(sexy_bash_prompt_get_symbol_color) = "#error-color" || echo 'sexy_bash_prompt_get_symbol_color did not return `#error-color` as expected' 1>&2
 

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -274,7 +274,7 @@ esc=$'\033'
     # test "$sexy_bash_prompt_user_color" = "$esc[1m$esc[38;5;27m" || echo '`sexy_bash_prompt_user_color` is not bold blue (256)' 1>&2
 
     # uses 256 color palette
-    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
+    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \['$esc'(B'$esc'[m\]'
 
     # DEV: To debug, use a diff tool. Don't stare at the code.
     # http://www.diffchecker.com/diff
@@ -289,7 +289,7 @@ esc=$'\033'
   $PROMPT_COMMAND
 
     # uses 8 color palette
-    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[34m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[36m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[32m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\['$esc'[1m\]$ \['$esc'(B'$esc'[m\]'
+    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[34m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[36m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[32m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (8)' 1>&2
 
   # in an ANSI terminal
@@ -311,7 +311,7 @@ esc=$'\033'
   $PROMPT_COMMAND
 
     # use the new colors
-    expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;33m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\[\033[1;36m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[\033[1;38m\]$ \['$esc'(B'$esc'[m\]'
+    expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;33m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\[\033[1;36m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (overridden)' 1>&2
 
   # with an error code
@@ -323,7 +323,7 @@ esc=$'\033'
   $PROMPT_COMMAND
 
     # uses red prompt symbol
-    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\['$esc'[1m'$esc'[31m\]$ \['$esc'(B'$esc'[m\]'
+    expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[38;5;27m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;39m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;76m\]\w\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[38;5;154m\]$(sexy_bash_prompt_get_git_info)\['$esc'[1m'$esc'[91m\]$(sexy_bash_prompt_get_git_progress)\['$esc'(B'$esc'[m\]\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (error-code)' 1>&2
 
 # prompt status symbols

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -1,6 +1,3 @@
-# Enable history for accurate past command testing
-set -o history
-
 # Navigate to test directory
 ORIG_PWD="$PWD"
 TEST_DIR="$PWD/test"
@@ -326,12 +323,16 @@ esc=$'\033'
     # a successful command uses the default color
     true
     $PROMPT_COMMAND
+    # DEV: Stub out last command being checked against
+    sexy_bash_prompt_last_command="valid command"
 
     test $(sexy_bash_prompt_get_symbol_color) = "#default-color" || echo 'sexy_bash_prompt_get_symbol_color did not return `#default-color` as expected' 1>&2
 
     # an errored command uses the error color
     false
     $PROMPT_COMMAND
+    # DEV: Stub out last command being checked against
+    sexy_bash_prompt_last_command="invalid command"
 
     test $(sexy_bash_prompt_get_symbol_color) = "#error-color" || echo 'sexy_bash_prompt_get_symbol_color did not return `#error-color` as expected' 1>&2
 

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -18,10 +18,14 @@ fixture_git_init() {
   git init 1> /dev/null
 }
 
+run_bash_prompt() {
+  PROMPT_COMMAND=""
+  . .bash_prompt
+  $PROMPT_COMMAND
+}
+
 # Load in bash_prompt
-PROMPT_COMMAND=""
-. .bash_prompt
-$PROMPT_COMMAND
+run_bash_prompt
 
 # sexy_bash_prompt_is_on_git
 
@@ -265,9 +269,7 @@ cd "$ORIG_PWD"
 esc=$'\033'
 
   # in a 256 color terminal
-  PROMPT_COMMAND=""
-  TERM=xterm-256color . .bash_prompt
-  $PROMPT_COMMAND
+  TERM=xterm-256color run_bash_prompt
 
     # Deprecated color by color test, not used because requires double maintenance
     # echo "$(TERM=xterm-256color tput bold)$(TERM=xterm-256color tput setaf 27)" | copy
@@ -284,31 +286,25 @@ esc=$'\033'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (256)' 1>&2
 
   # in an 8 color terminal
-  PROMPT_COMMAND=""
-  TERM=xterm . .bash_prompt
-  $PROMPT_COMMAND
+  TERM=xterm run_bash_prompt
 
     # uses 8 color palette
     expected_prompt='\['$esc'(B'$esc'[m\]\['$esc'[1m'$esc'[34m\]\u\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]at\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[36m\]\h\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[37m\]in\['$esc'(B'$esc'[m\] \['$esc'[1m'$esc'[32m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \['$esc'[1m'$esc'[37m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\['$esc'[1m'$esc'[33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\['$esc'[1m'$esc'[31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \['$esc'(B'$esc'[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (8)' 1>&2
 
   # in an ANSI terminal
-  PROMPT_COMMAND=""
-  TERM="" . .bash_prompt
-  $PROMPT_COMMAND
+  TERM="" run_bash_prompt
 
     # uses ANSI colors
     expected_prompt='\[\033[m\]\[\033[1;34m\]\u\[\033[m\] \[\033[1;37m\]at\[\033[m\] \[\033[1;36m\]\h\[\033[m\] \[\033[1;37m\]in\[\033[m\] \[\033[1;32m\]\w\[\033[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;37m\]on\[\033[m\] " &&   echo -n "\[\033[1;33m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;31m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\[\033[m\]")\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \[\033[m\]'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (ANSI)' 1>&2
 
   # when overridden
-  PROMPT_COMMAND=""
   TERM=xterm-256color PROMPT_USER_COLOR='\033[1;32m' \
     PROMPT_PREPOSITION_COLOR='\033[1;33m' PROMPT_DEVICE_COLOR='\033[1;34m' \
     PROMPT_DIR_COLOR='\033[1;35m' PROMPT_GIT_STATUS_COLOR='\033[1;36m'  \
     PROMPT_GIT_PROGRESS_COLOR='\033[1;37m' PROMPT_SYMBOL_COLOR='\033[1;38m' \
-    . .bash_prompt
-  $PROMPT_COMMAND
+    run_bash_prompt
 
     # use the new colors
     expected_prompt='\['$esc'(B'$esc'[m\]\[\033[1;32m\]\u\['$esc'(B'$esc'[m\] \[\033[1;33m\]at\['$esc'(B'$esc'[m\] \[\033[1;34m\]\h\['$esc'(B'$esc'[m\] \[\033[1;33m\]in\['$esc'(B'$esc'[m\] \[\033[1;35m\]\w\['$esc'(B'$esc'[m\]$( sexy_bash_prompt_is_on_git &&   echo -n " \[\033[1;33m\]on\['$esc'(B'$esc'[m\] " &&   echo -n "\[\033[1;36m\]$(sexy_bash_prompt_get_git_info)" &&   echo -n "\[\033[1;37m\]$(sexy_bash_prompt_get_git_progress)" &&   echo -n "\['$esc'(B'$esc'[m\]")\n\[$(sexy_bash_prompt_get_symbol_color)\]$ \['$esc'(B'$esc'[m\]'
@@ -316,9 +312,8 @@ esc=$'\033'
 
 # prompt symbol color
   # when overridden
-  PROMPT_COMMAND=""
   PROMPT_SYMBOL_COLOR='#default-color' PROMPT_SYMBOL_ERROR_COLOR='#error-color' \
-    . .bash_prompt
+    run_bash_prompt
 
     # a successful command uses the default color
     true
@@ -338,14 +333,12 @@ esc=$'\033'
 
 # prompt status symbols
   # when overridden
-  PROMPT_COMMAND=""
   PROMPT_SYNCED_SYMBOL='#synced' PROMPT_DIRTY_SYNCED_SYMBOL='#dirty-synced' \
     PROMPT_UNPUSHED_SYMBOL='#unpushed' PROMPT_DIRTY_UNPUSHED_SYMBOL='#dirty-unpushed' \
     PROMPT_UNPULLED_SYMBOL='#unpulled' PROMPT_DIRTY_UNPULLED_SYMBOL='#dirty-unpulled' \
     PROMPT_UNPUSHED_UNPULLED_SYMBOL='#unpushed-unpulled' PROMPT_DIRTY_UNPUSHED_UNPULLED_SYMBOL='#dirty-unpushed-unpulled' \
     PROMPT_SYMBOL='#prompt-symbol' \
-    . .bash_prompt
-  $PROMPT_COMMAND
+    run_bash_prompt
 
     # the prompt always uses the PROMPT_SYMBOL
     test "$sexy_bash_prompt_symbol" = "#prompt-symbol" || echo 'sexy_bash_prompt_symbol was not overridden by PROMPT_SYMBOL as expected' 1>&2

--- a/test/prompt_test.sh
+++ b/test/prompt_test.sh
@@ -19,7 +19,9 @@ fixture_git_init() {
 }
 
 # Load in bash_prompt
+PROMPT_COMMAND=""
 . .bash_prompt
+$PROMPT_COMMAND
 
 # sexy_bash_prompt_is_on_git
 
@@ -263,6 +265,7 @@ cd "$ORIG_PWD"
 esc=$'\033'
 
   # in a 256 color terminal
+  PROMPT_COMMAND=""
   TERM=xterm-256color . .bash_prompt
   $PROMPT_COMMAND
 
@@ -281,6 +284,7 @@ esc=$'\033'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (256)' 1>&2
 
   # in an 8 color terminal
+  PROMPT_COMMAND=""
   TERM=xterm . .bash_prompt
   $PROMPT_COMMAND
 
@@ -289,6 +293,7 @@ esc=$'\033'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (8)' 1>&2
 
   # in an ANSI terminal
+  PROMPT_COMMAND=""
   TERM="" . .bash_prompt
   $PROMPT_COMMAND
 
@@ -297,6 +302,7 @@ esc=$'\033'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (ANSI)' 1>&2
 
   # when overridden
+  PROMPT_COMMAND=""
   TERM=xterm-256color PROMPT_USER_COLOR='\033[1;32m' \
     PROMPT_PREPOSITION_COLOR='\033[1;33m' PROMPT_DEVICE_COLOR='\033[1;34m' \
     PROMPT_DIR_COLOR='\033[1;35m' PROMPT_GIT_STATUS_COLOR='\033[1;36m'  \
@@ -309,6 +315,7 @@ esc=$'\033'
     test "$PS1" = "$expected_prompt" || echo '`PS1` is not as expected (overridden)' 1>&2
 
   # with an error code
+  PROMPT_COMMAND=""
   TERM=xterm-256color . .bash_prompt
   # DEV: Stub out last command being checked against
   sexy_bash_prompt_last_command="invalid command"
@@ -321,6 +328,7 @@ esc=$'\033'
 
 # prompt status symbols
   # when overridden
+  PROMPT_COMMAND=""
   PROMPT_SYNCED_SYMBOL='#synced' PROMPT_DIRTY_SYNCED_SYMBOL='#dirty-synced' \
     PROMPT_UNPUSHED_SYMBOL='#unpushed' PROMPT_DIRTY_UNPUSHED_SYMBOL='#dirty-unpushed' \
     PROMPT_UNPULLED_SYMBOL='#unpulled' PROMPT_DIRTY_UNPULLED_SYMBOL='#dirty-unpulled' \


### PR DESCRIPTION
In #88 and #89, we moved to `PROMPT_COMMAND` and added exit code support. In #90, we discovered we broke existing `PS1` extension mechanisms due to always setting the variable

This PR moves to a hybrid where we track the items we need for exit code support via a `PROMPT_COMMAND` hook and exposes them as globals

In this PR:

- Added back same exit code config, logic, and documentation
- Added back Travis CI notification patch
- Patched `PROMPT_COMMAND` as a hook, to only expose globals for `PS1`
- Added `PROMPT_COMMAND` extension logic
- Updated `PS1` to use globals from `PROMPT_COMMAND`
- Updated tests
- Fixes #82 again

/cc @rpdelaney 