### PR TITLE
Do not duplicate `sexy_bash_prompt_command` in PROMPT_COMMAND

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -312,7 +312,10 @@ sexy_bash_prompt_command () {
 }
 # DEV: Extend `PROMPT_COMMAND` if there already is one
 if [[ "$PROMPT_COMMAND" != "" ]]; then
-  PROMPT_COMMAND="sexy_bash_prompt_command ; $PROMPT_COMMAND"
+  # DEV: Do not duplicate `sexy_bash_prompt_command` in PROMPT_COMMAND
+  if ! grep 'sexy_bash_prompt_command' <<< "$PROMPT_COMMAND" &> /dev/null; then
+    PROMPT_COMMAND="sexy_bash_prompt_command ; $PROMPT_COMMAND"
+  fi
 else
   PROMPT_COMMAND="sexy_bash_prompt_command"
 fi


### PR DESCRIPTION
Hi,
When sourcing a second time my bashrc, PROMPT_COMMAND value is "sexy_bash_prompt_command ; sexy_bash_prompt_command ; others_stuffs". The second call of `sexy_bash_prompt_command` reset `sexy_bash_prompt_exit_code` to 0.
Grepping the function name in PROMPT_COMMAND is used to avoid this.

Have a good day !